### PR TITLE
fix NormalizeLocation's fs path joining on win32

### DIFF
--- a/pyxb/utils/utility.py
+++ b/pyxb/utils/utility.py
@@ -24,6 +24,7 @@ import time
 import datetime
 import logging
 from pyxb.utils import six
+import sys
 
 _log = logging.getLogger(__name__)
 
@@ -706,7 +707,14 @@ def NormalizeLocation (uri, parent_uri=None, prefix_map=None):
     else:
         #if (0 > parent_uri.find(':')) and (not parent_uri.endswith(os.sep)):
         #    parent_uri = parent_uri + os.sep
-        abs_uri = urlparse.urljoin(parent_uri, uri)
+
+        # 'urljoin' doesn't work on windows file system paths.
+        # This should not affect actual URIs as they should not contain
+        # '\'; they should be percent encoded as %5C.
+        if sys.platform == 'win32' and os.sep in parent_uri:
+            abs_uri = os.path.join(os.path.dirname(parent_uri), uri)
+        else:
+            abs_uri = urlparse.urljoin(parent_uri, uri)
     if prefix_map is None:
         prefix_map = LocationPrefixRewriteMap_
     for (pfx, sub) in six.iteritems(prefix_map):


### PR DESCRIPTION
Symptom: relative schema imports for local files fail, pyxb tries to load the file from the current working directory rather than the path of the parent schema as it intends.

This is a win32-specific problem because urljoin should be fine on posix paths. On win32, the blackslash path separator and the fact that it identifies the drive letter as unknown scheme cause it to just return the second argument.

Real URIs should not contain a backslash and so should not be inadvertently targetted here.

Side-node - I can see other lines where pyxb seems to think that the presence of ':' is a reliable way of distinguishing URIs from file system paths. On windows this doesn't work because absolute paths will always contain a drive letter followed by : .. 