### PR TITLE
Fix for import winreg module on linux

### DIFF
--- a/pyxb/utils/six.py
+++ b/pyxb/utils/six.py
@@ -243,6 +243,10 @@ _moved_attributes = [
     MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
     MovedModule("winreg", "_winreg"),
 ]
+
+if sys.platform == "win32":
+    _moved_attributes.append(MovedModule("winreg", "_winreg"))
+
 for attr in _moved_attributes:
     setattr(_MovedItems, attr.name, attr)
     if isinstance(attr, MovedModule):

--- a/pyxb/utils/six.py
+++ b/pyxb/utils/six.py
@@ -241,9 +241,9 @@ _moved_attributes = [
     MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
     MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
     MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
-    MovedModule("winreg", "_winreg"),
 ]
 
+# prevenf for 
 if sys.platform == "win32":
     _moved_attributes.append(MovedModule("winreg", "_winreg"))
 


### PR DESCRIPTION
I have problem on linux with six from pyxb.utils, because of winreg_:

ImportError: No module named _winreg

Can you accept this pull request? This is simple fix for that problem.
Thanks in advance!