### PR TITLE
test_utility.TestGetMatchingFiles: Fix for paths containing dots.

### DIFF
--- a/tests/utils/test-utility.py
+++ b/tests/utils/test-utility.py
@@ -584,7 +584,7 @@ import os
 import re
 class TestGetMatchingFiles (unittest.TestCase):
     __WXS_re = re.compile('\.wxs$')
-    __NoExt_re = re.compile('^[^\.]*$')
+    __NoExt_re = re.compile('(^|\%s)[^\.]+$' % os.sep)
     __directory = None
     def setUp (self):
         self.__directory = tempfile.mkdtemp()


### PR DESCRIPTION
Hi, I'm packaging PyXB for GNU Guix which sets TMPDIR as `/tmp/guix-build-python-pyxb-1.2.4-0`. This caused https://github.com/pabigot/pyxb/blob/master/tests/utils/test-utility.py#L694 to fail because `__NoExt_re` matches the directory that precedes the temporary files.

You can reproduce it by e.g. `mkdir /tmp/path.with.dots; TMPDIR=/tmp/path.with.dots python setup.py test`.

The following commit should fix it. Escaping `%s` is not strictly necessary on Unix, but does not seem to hurt, and I think it's required on platforms with more awkward directory separators. Changing `*` to `+` is optional :)

Thanks!