### PR TITLE
Added support for seconds specifier with large magnitude

### DIFF
--- a/pyxb/binding/datatypes.py
+++ b/pyxb/binding/datatypes.py
@@ -363,7 +363,7 @@ class duration (basis.simpleTypeDefinition, datetime.timedelta, basis._Represent
                 time_elts.append('%d%s' % (v, k[0].upper()))
         v = value.__durationData.get('seconds', 0)
         if 0 != v:
-            time_elts.append('%gS' % (v,))
+            time_elts.append(('%f' % (v,)).rstrip('0').rstrip('.') + 'S')
         if 0 < len(time_elts):
             elts.append('T')
             elts.extend(time_elts)

--- a/tests/datatypes/test-duration.py
+++ b/tests/datatypes/test-duration.py
@@ -39,6 +39,16 @@ class Test_duration (unittest.TestCase):
         self.assertEqual(1347, v.durationData()['months'])
         self.assertEqual('P1347M', v.xsdLiteral())
 
+        v = xsd.duration('PT2000000000S')
+        self.assertEqual(int(2000000000 / 60 / 60 / 24), v.days)
+        self.assertEqual(int(round(((2000000000.0 / 60.0 / 60.0 / 24.0) - int(2000000000 / 60 / 60 / 24)) *24 *60 *60)), v.seconds)
+        self.assertEqual('PT2000000000S', v.xsdLiteral())
+
+        v = xsd.duration('PT2000000000.2S')
+        self.assertEqual(int(2000000000.2 / 60 / 60 / 24), v.days)
+        self.assertEqual(int(round(((2000000000.2 / 60.0 / 60.0 / 24.0) - int(2000000000.2 / 60 / 60 / 24)) *24 *60 *60)), v.seconds)
+        self.assertEqual('PT2000000000.2S', v.xsdLiteral())
+
         v = xsd.duration('P0Y1347M0D')
         self.assertEqual(0, v.days)
         self.assertEqual(0, v.seconds)


### PR DESCRIPTION
This fix provides support for large magnitude seconds.

When writing xsd, I wanted to have a `maxInclusive` value for xs:duration of 2^31-1 (approx 68 years).  For me, it made sense to use the seconds derivative of: 2147483647.  Because the general format string formatter (`%g`) was being used, this value was converted to scientific notation and failing the duration regex: `__Lexical_re = re.compile('^(?P<neg>-?)P((?P<years>\d+)Y)?((?P<months>\d+)M)?((?P<     days>\d+)D)?(?P<Time>T((?P<hours>\d+)H)?((?P<minutes>\d+)M)?(((?P<seconds>\d+)(?P<frac     sec>\.\d+)?)S)?)?$')`.