### PR TITLE
Do not normalize decimal types, trailing zeros should be kept if needed

### DIFF
--- a/pyxb/binding/datatypes.py
+++ b/pyxb/binding/datatypes.py
@@ -157,7 +157,7 @@ class decimal (basis.simpleTypeDefinition, python_decimal.Decimal, basis._Repres
 
     @classmethod
     def XsdLiteral (cls, value):
-        (sign, digits, exponent) = value.normalize().as_tuple()
+        (sign, digits, exponent) = value.as_tuple()
         if (0 < len(digits)) and (0 == digits[0]):
             digits = ()
         rchars = []


### PR DESCRIPTION
Steps to reproduce:

 - Generate bindings using schema similar to https://www.agenziaentrate.gov.it/wps/file/Nsilib/Nsi/Schede/Comunicazioni/Fatture+e+corrispettivi/Fatture+e+corrispettivi+ST/ST+invio+di+fatturazione+elettronica/ST+Fatturazione+elettronica+-+Schema+VFPR12./Schema_VFPR12.xsd where you can find `QuantitaType` defined as
```
  <xs:simpleType name="QuantitaType">
    <xs:restriction base="xs:decimal">
      <xs:pattern value="[0-9]{1,12}\.[0-9]{2,8}" />
    </xs:restriction>
  </xs:simpleType>
```
 - Using bindings, create `FatturaElettronica` setting `Quantita='1.000'`
 - Generate XML with `toxml("UTF-8")`

get
```
[...]
<Quantita>1.0</Quantita>
[...]
```

**Expected behaviour:**

get
```
[...]
<Quantita>1.000</Quantita>
[...]
```
