### PR TITLE
Add a small hack to handle the timedelta changes in Python 3.8

### DIFF
--- a/pyxb/binding/datatypes.py
+++ b/pyxb/binding/datatypes.py
@@ -669,6 +669,10 @@ class _PyXBDateOnly_base (_PyXBDateTime_base, datetime.datetime):
                 except AttributeError:
                     pass
             else:
+                # A terrible hack for handling Python 3.8's update to how timedeltas are handled.
+                if len(args) == 8 and all(type(a) in (int, None) for a in args):
+                    args = args[:3] + args[-1:]
+
                 fi = 0
                 while fi < len(cls._ValidFields):
                     fn = cls._ValidFields[fi]


### PR DESCRIPTION
Python 3.8 introduced a change to timedelta behavior that breaks PyXB:

> * Arithmetic operations between subclasses of `datetime.date` or `datetime.datetime` and `datetime.timedelta` objects now return an instance of the subclass, rather than the base class. This also affects the return type of operations whose implementation (directly or indirectly) uses `datetime.timedelta` arithmetic, such as `astimezone()`. (Contributed by Paul Ganssle in [bpo-32417](https://bugs.python.org/issue32417).)

This PR implements a small hack to bypass this incompatibility.